### PR TITLE
Use an inline attribute for SSE 4.2 availablity

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,7 @@ let package = Package(
             swiftSettings: [
             .define("USE_HARDWARE")
         ]),
-        .target(name: "CIntelCRC",
-                dependencies: [],
-                cSettings: [
-                    .unsafeFlags(["-msse4.2"]),
-                ]),
+        .target(name: "CIntelCRC"),
         .testTarget(
             name: "CRC32CTests",
             dependencies: ["CRC32C"]),

--- a/Sources/CIntelCRC/CIntelCRC.c
+++ b/Sources/CIntelCRC/CIntelCRC.c
@@ -15,6 +15,7 @@ static inline uint32_t shift(const uint32_t table[][256], uint32_t crc)
         ^ table[3][crc >> 24];
 }
 
+__attribute__((target("sse4.2")))
 uint32_t intel_crc(uint32_t crc, const uint8_t* data, size_t length)
 {
     const uint8_t* next = data;


### PR DESCRIPTION
Annotate `intel_crc` rather than using passing an unsafe `-msse4.2` to the compiler in the Swift Package definition.

Thank you @stephentyrone (https://forums.swift.org/t/usage-of-cpu-intrinsics-in-spm-projects/40887)